### PR TITLE
Add color support for Windows CMD / Powershell

### DIFF
--- a/testes.nim
+++ b/testes.nim
@@ -523,6 +523,10 @@ proc findName(n: NimNode; index: int): string =
       repr(n)
   else:
     result = repr(n)
+ 
+# windows cmd / powershell color support
+when defined(windows):
+  discard execShellCmd("")
 
 macro testes*(tests: untyped) =
   ## for a good time, put your tests in `block:` underneath the `testes`


### PR DESCRIPTION
Don't exactly understand how it works, but it allows ANSI escape sequences in those shells.